### PR TITLE
Add GSAP animations and usage guide

### DIFF
--- a/in_browser_demo_claude/README.md
+++ b/in_browser_demo_claude/README.md
@@ -1,0 +1,26 @@
+# In-Browser Slide Demo
+
+This folder contains a standalone HTML page for creating and presenting slides with
+GrapesJS, Reveal.js and PptxGenJS. A small GSAP animation is also included for
+slide transitions.
+
+## Usage
+
+1. Start a simple web server in this directory:
+   ```bash
+   python3 -m http.server 8000
+   ```
+   Then open `http://localhost:8000/main.html` in your browser.
+
+2. **LLM HTML Input** – Paste raw HTML for each slide and click **Process Slides**.
+
+3. **Edit Slides** – Switch to the second tab to tweak the layout using GrapesJS.
+   After editing, press **Save Edits**.
+
+4. **Present** – Use the third tab to run the slideshow. Each slide fades in with
+   a GSAP animation. Use the **Start Presentation** button for fullscreen mode.
+
+5. **Export PPT** – The last tab converts your slides to a PowerPoint file using
+   PptxGenJS.
+
+This page does not require any backend; all processing happens in your browser.

--- a/in_browser_demo_claude/main.html
+++ b/in_browser_demo_claude/main.html
@@ -21,6 +21,10 @@
     <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js" onload="onScriptLoad()"
         onerror="console.error('Failed to load PptxGenJS')"></script>
 
+    <!-- GSAP for simple slide animations -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" onload="onScriptLoad()"
+        onerror="console.error('Failed to load GSAP')"></script>
+
     <style>
         * {
             box-sizing: border-box;
@@ -321,7 +325,8 @@
             const libs = [
                 { name: 'GrapesJS', check: () => typeof grapesjs !== 'undefined' },
                 { name: 'Reveal.js', check: () => typeof Reveal !== 'undefined' },
-                { name: 'PptxGenJS', check: () => typeof PptxGenJS !== 'undefined' }
+                { name: 'PptxGenJS', check: () => typeof PptxGenJS !== 'undefined' },
+                { name: 'GSAP', check: () => typeof gsap !== 'undefined' }
             ];
 
             libs.forEach(lib => {
@@ -332,7 +337,7 @@
 
         // Wait for all scripts to load
         let scriptsLoaded = 0;
-        const totalScripts = 3;
+        const totalScripts = 4;
 
         function onScriptLoad() {
             scriptsLoaded++;
@@ -529,7 +534,17 @@
             alert('Slide edits saved! You can now view them in Tab 3.');
         }
 
-        // Reveal.js Presentation (Tab 3)  
+        // Reveal.js Presentation (Tab 3)
+        function animateSlide(slideEl) {
+            if (!slideEl || typeof gsap === 'undefined') return;
+            gsap.fromTo(slideEl.children, { opacity: 0, y: 30 }, {
+                opacity: 1,
+                y: 0,
+                duration: 0.6,
+                stagger: 0.1
+            });
+        }
+
         function updateRevealSlides() {
             if (typeof Reveal === 'undefined') {
                 console.error('Reveal.js not loaded');
@@ -569,7 +584,12 @@
                     transition: 'slide'
                 });
 
+                reveal.on('slidechanged', event => {
+                    animateSlide(event.currentSlide);
+                });
+
                 reveal.initialize();
+                animateSlide(reveal.getCurrentSlide());
                 console.log('Reveal.js initialized successfully');
             } catch (error) {
                 console.error('Failed to initialize Reveal.js:', error);


### PR DESCRIPTION
## Summary
- integrate GSAP into the slide demo
- trigger simple fade/slide animation when changing slides
- document demo workflow in a new README

## Testing
- `python -m py_compile app.py`
- `python -m py_compile test.py`

------
https://chatgpt.com/codex/tasks/task_e_685d370adfe48327b5cee36307eff03b